### PR TITLE
docs: fix simple typo, clearity -> clarity

### DIFF
--- a/mini3d.c
+++ b/mini3d.c
@@ -11,7 +11,7 @@
 //   2007.7.02  skywind  implementate texture and color render
 //   2008.3.15  skywind  fixed a trapezoid issue
 //   2015.8.09  skywind  rewrite with more comment
-//   2015.8.12  skywind  adjust interfaces for clearity 
+//   2015.8.12  skywind  adjust interfaces for clarity 
 // 
 //=====================================================================
 #include <stdio.h>


### PR DESCRIPTION
There is a small typo in mini3d.c.

Should read `clarity` rather than `clearity`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md